### PR TITLE
[FIX] business_requirement_deliverable: Issues when try save BR with …

### DIFF
--- a/business_requirement_deliverable/models/business.py
+++ b/business_requirement_deliverable/models/business.py
@@ -125,21 +125,23 @@ class BusinessRequirementDeliverable(models.Model):
     @api.multi
     @api.depends('business_requirement_id.partner_id')
     def _compute_get_currency(self):
-        partner_id = self.business_requirement_id.partner_id
-        currency_id = partner_id.property_product_pricelist.currency_id
-        if currency_id:
-            self.currency_id = currency_id
+        for brd in self:
+            partner_id = brd.business_requirement_id.partner_id
+            currency_id = partner_id.property_product_pricelist.currency_id
+            if currency_id:
+                brd.currency_id = currency_id
 
     @api.multi
     def _get_pricelist(self):
-        if self.business_requirement_id and (
-            self.business_requirement_id.partner_id
-        ) and (
-            self.business_requirement_id.partner_id.property_product_pricelist
-        ):
-            return self.business_requirement_id.partner_id.\
-                property_product_pricelist
-        return False
+        for brd in self:
+            partner_id = False
+            if brd.business_requirement_id and (
+                brd.business_requirement_id.partner_id
+            ):
+                partner_id = brd.business_requirement_id.partner_id
+            if partner_id and partner_id.property_product_pricelist:
+                return partner_id.property_product_pricelist
+            return partner_id
 
     @api.multi
     @api.depends('unit_price', 'qty')


### PR DESCRIPTION
…more than one deliverable lines.

```
modified:   business_requirement_deliverable/models/business.py
```

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-240640641%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-240641714%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-240648871%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-240717043%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-240907126%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-241022665%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-241639811%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-241680033%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/OCA/business-requirement/pull/14%23issuecomment-240640641%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/7500964/badge%29%5D%28https%3A//coveralls.io/builds/7500964%29%5Cn%5CnCoverage%20increased%20%28%2B0.2%25%29%20to%2090.654%25%20when%20pulling%20%2A%2A54e0da4b069a8f39e41d965c9179996408948ca0%20on%20victormartinelicocorp%3A8.0-1_business_requirement_deliverable-fix-issues%2A%2A%20into%20%2A%2A843f43882a9641f9b63988b1d9099b1ec51c47f6%20on%20OCA%3A8.0%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-08-18T07%3A01%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40elicoidal%20%22%2C%20%22created_at%22%3A%20%222016-08-18T07%3A08%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16461806%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/victormartinelicocorp%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-08-18T07%3A47%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7600613%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elicoidal%22%7D%7D%2C%20%7B%22body%22%3A%20%22These%20are%20the%20cases%20where%20%60%40api.one%60%20would%20be%20a%20big%20help...%5Cr%5Cn%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-08-18T13%3A06%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1246629%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dreispt%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40dreispt%20yes%20but%20I%20try%20not%20use%20it%20anymore%20since%20it%27s%20deprecated%20%28thinking%20about%20porting%20to%20v9%29%22%2C%20%22created_at%22%3A%20%222016-08-19T01%3A51%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16461806%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/victormartinelicocorp%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40victormartinelicocorp%20Yes%2C%20I%20know.%20My%20point%20is%20that%20this%20illustrates%20why%20it%20should%20be%20de-deprecated.%22%2C%20%22created_at%22%3A%20%222016-08-19T13%3A47%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1246629%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dreispt%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20%40dreispt%2C%20now%20I%20get%20your%20point%2C%20also%20for%20me%20is%20easier%20use%20%60%40api.one%60%20%5Cr%5CnNot%20sure%20if%20I%20need%20to%20change%20it%20here%20and%20next%20version%20if%20it%27s%20blocking%20change%20it%20by%20%60%40api.multi%60%5Cr%5Cncc%20%40elicoidal%20%22%2C%20%22created_at%22%3A%20%222016-08-23T06%3A33%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/16461806%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/victormartinelicocorp%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40victormartinelicocorp%20the%20matter%20is%20not%20settled%20for%20api.one%20%28ongoing%20discussion%3A%20https%3A//github.com/odoo/odoo/pull/13199%23issuecomment-240725520%29%20so%20let%27s%20keep%20it%20as%20it%20is%20now.%22%2C%20%22created_at%22%3A%20%222016-08-23T09%3A41%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7600613%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elicoidal%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/OCA/business-requirement/pull/14#issuecomment-240640641'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/7500964/badge)](https://coveralls.io/builds/7500964)
  Coverage increased (+0.2%) to 90.654% when pulling **54e0da4b069a8f39e41d965c9179996408948ca0 on victormartinelicocorp:8.0-1_business_requirement_deliverable-fix-issues** into **843f43882a9641f9b63988b1d9099b1ec51c47f6 on OCA:8.0**.
- <a href='https://github.com/victormartinelicocorp'><img border=0 src='https://avatars.githubusercontent.com/u/16461806?v=3' height=16 width=16'></a> @elicoidal
- <a href='https://github.com/elicoidal'><img border=0 src='https://avatars.githubusercontent.com/u/7600613?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/dreispt'><img border=0 src='https://avatars.githubusercontent.com/u/1246629?v=3' height=16 width=16'></a> These are the cases where `@api.one` would be a big help...
  :+1:
- <a href='https://github.com/victormartinelicocorp'><img border=0 src='https://avatars.githubusercontent.com/u/16461806?v=3' height=16 width=16'></a> @dreispt yes but I try not use it anymore since it's deprecated (thinking about porting to v9)
- <a href='https://github.com/dreispt'><img border=0 src='https://avatars.githubusercontent.com/u/1246629?v=3' height=16 width=16'></a> @victormartinelicocorp Yes, I know. My point is that this illustrates why it should be de-deprecated.
- <a href='https://github.com/victormartinelicocorp'><img border=0 src='https://avatars.githubusercontent.com/u/16461806?v=3' height=16 width=16'></a> Thanks @dreispt, now I get your point, also for me is easier use `@api.one`
  Not sure if I need to change it here and next version if it's blocking change it by `@api.multi`
  cc @elicoidal
- <a href='https://github.com/elicoidal'><img border=0 src='https://avatars.githubusercontent.com/u/7600613?v=3' height=16 width=16'></a> @victormartinelicocorp the matter is not settled for api.one (ongoing discussion: https://github.com/odoo/odoo/pull/13199#issuecomment-240725520) so let's keep it as it is now.

<a href='https://www.codereviewhub.com/OCA/business-requirement/pull/14?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/OCA/business-requirement/pull/14?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/OCA/business-requirement/pull/14'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
