### PR TITLE
Update image link as they where not visible in app

### DIFF
--- a/business_requirement/README.rst
+++ b/business_requirement/README.rst
@@ -55,7 +55,7 @@ can be used as a standalone module.
 .. figure:: ../business_requirement/static/img/bus_req_tree.png
    :width: 600 px
 
-.. figure:: static/img/bus_req_tree.png
+.. figure:: business_requirement/static/img/bus_req_tree.png
    :width: 600 px
 
 Multiple modules integrate the BR with other business areas, such as Sales, 
@@ -68,7 +68,7 @@ Procurement, Project or Analytic Accounting. For example:
 .. figure:: ../business_requirement/static/img/bus_req_module_diag.png
    :width: 600 px
 
-.. figure:: static/img/bus_req_module_diag.png
+.. figure:: business_requirement/static/img/bus_req_module_diag.png
    :width: 600 px
 
 The following workflow explains the business workflow between the BR modules and other applications in Odoo:
@@ -76,7 +76,7 @@ The following workflow explains the business workflow between the BR modules and
 .. figure:: ../business_requirement/static/img/bus_req_workflow.png
    :width: 600 px
 
-.. figure:: static/img/bus_req_workflow.png
+.. figure:: business_requirement/static/img/bus_req_workflow.png
    :width: 600 px
 
 
@@ -92,7 +92,7 @@ This module only contains the standard base models for business requirement:
 .. figure:: ../business_requirement/static/img/bus_req.png
    :width: 600 px
 
-.. figure:: static/img/bus_req.png
+.. figure:: business_requirement/static/img/bus_req.png
    :width: 600 px
 
 
@@ -113,7 +113,7 @@ business requirements directly from email received at a specific address.
 .. figure:: ../business_requirement/static/img/bus_req_alias.png
    :width: 600 px
 
-.. figure:: static/img/bus_req_alias.png
+.. figure::business_requirement/static/img/bus_req_alias.png
    :width: 600 px
 
 You can start conversation with the followers in the chatter area of the 
@@ -136,7 +136,7 @@ You can create and assign tags for your business requirements in Business Requir
 .. figure:: ../business_requirement/static/img/bus_req_tags.png
    :width: 600 px
 
-.. figure:: static/img/bus_req_tags.png
+.. figure::business_requirement/static/img/bus_req_tags.png
    :width: 600 px
 
 Master project
@@ -163,7 +163,7 @@ Simple BR
    .. figure:: ../business_requirement/static/img/bus_req_tags2.png
       :width: 600 px
 
-   .. figure:: static/img/bus_req_tags2.png
+   .. figure::business_requirement/static/img/bus_req_tags2.png
       :width: 600 px
 
 2. Input the customer story, scenario and gap (simple html editor with image and text)
@@ -171,7 +171,7 @@ Simple BR
    .. figure:: ../business_requirement/static/img/bus_req_cust_story.png
       :width: 600 px
 
-   .. figure:: static/img/bus_req_cust_story.png
+   .. figure::business_requirement/static/img/bus_req_cust_story.png
       :width: 600 px
 
 3. Confirm the Business requirement (for BR User and Manager)
@@ -180,7 +180,7 @@ Simple BR
    .. figure:: ../business_requirement/static/img/bus_req_confirmed.png
       :width: 600 px
 
-   .. figure:: static/img/bus_req_confirmed.png
+   .. figure::business_requirement/static/img/bus_req_confirmed.png
       :width: 600 px
     
 4. Approve the Business requirement (for BR Manager)
@@ -188,7 +188,7 @@ Simple BR
    .. figure:: ../business_requirement/static/img/bus_req_approved.png
       :width: 600 px
 
-   .. figure:: static/img/bus_req_approved.png
+   .. figure::business_requirement/static/img/bus_req_approved.png
       :width: 600 px
     
 5. Once your requirement is finished and delivered you can set it as Done
@@ -196,7 +196,7 @@ Simple BR
    .. figure:: ../business_requirement/static/img/bus_req_done.png
       :width: 600 px
 
-   .. figure:: static/img/bus_req_done.png
+   .. figure::business_requirement/static/img/bus_req_done.png
       :width: 600 px
     
 6. Alternatively, you can cancel the BR (in case it is not relevant or mistake) or drop it (when customer makes the decision to discontinue it)
@@ -204,14 +204,14 @@ Simple BR
    .. figure:: ../business_requirement/static/img/bus_req_cancel.png
       :width: 600 px
 
-   .. figure:: static/img/bus_req_cancel.png
+   .. figure::business_requirement/static/img/bus_req_cancel.png
       :width: 600 px
     
     
    .. figure:: ../business_requirement/static/img/bus_req_drop.png
       :width: 600 px
 
-   .. figure:: static/img/bus_req_drop.png
+   .. figure::business_requirement/static/img/bus_req_drop.png
       :width: 600 px
     
 

--- a/business_requirement/README.rst
+++ b/business_requirement/README.rst
@@ -52,9 +52,11 @@ This module is part of a set (`Business Requirements repo <https://github.com/OC
 The base Business Requirements module creates the basic objects and 
 can be used as a standalone module.
 
+.. figure:: ../business_requirement/static/img/bus_req_tree.png
+   :width: 600 px
+
 .. figure:: static/img/bus_req_tree.png
    :width: 600 px
-   :alt: Business Requirement List view
 
 Multiple modules integrate the BR with other business areas, such as Sales, 
 Procurement, Project or Analytic Accounting. For example:
@@ -63,15 +65,19 @@ Procurement, Project or Analytic Accounting. For example:
 * Project Tasks can be related to the BRs they implement or support
 * Procurement and purchase can be generated out of the BR
 
+.. figure:: ../business_requirement/static/img/bus_req_module_diag.png
+   :width: 600 px
+
 .. figure:: static/img/bus_req_module_diag.png
    :width: 600 px
-   :alt: Business Requirement modules diagram
 
 The following workflow explains the business workflow between the BR modules and other applications in Odoo:
 
+.. figure:: ../business_requirement/static/img/bus_req_workflow.png
+   :width: 600 px
+
 .. figure:: static/img/bus_req_workflow.png
    :width: 600 px
-   :alt: Business Requirement integration in Odoo
 
 
 How to use this module?
@@ -83,9 +89,11 @@ This module only contains the standard base models for business requirement:
 * Standard setup and views
 * Standard Workflow
 
+.. figure:: ../business_requirement/static/img/bus_req.png
+   :width: 600 px
+
 .. figure:: static/img/bus_req.png
    :width: 600 px
-   :alt: Business Requirement Form
 
 
 Configuration
@@ -102,9 +110,11 @@ Alias and emails
 You can setup an alias in Settings/Technical/Email/Alias in order to create 
 business requirements directly from email received at a specific address.
 
+.. figure:: ../business_requirement/static/img/bus_req_alias.png
+   :width: 600 px
+
 .. figure:: static/img/bus_req_alias.png
    :width: 600 px
-   :alt: Email Alias setup
 
 You can start conversation with the followers in the chatter area of the 
 BR like in tasks, issue or CRM leads.
@@ -121,12 +131,13 @@ Search for Business Requirement sequence and alter it if necessary.
 Tags
 ----
 
-You can create and assign tags for your business requirements in Business Requirements/Configuration/Bus. Req. Category
+You can create and assign tags for your business requirements in Business Requirements/Configuration/Bus. Req. Category.
+
+.. figure:: ../business_requirement/static/img/bus_req_tags.png
+   :width: 600 px
 
 .. figure:: static/img/bus_req_tags.png
    :width: 600 px
-   :alt: Define Tags
-
 
 Master project
 --------------
@@ -149,45 +160,59 @@ Simple BR
    * Tags: any relevant tag for the business.
    * Owner and approver by default
    
+   .. figure:: ../business_requirement/static/img/bus_req_tags2.png
+      :width: 600 px
+
    .. figure:: static/img/bus_req_tags2.png
       :width: 600 px
-      :alt: Input header information
-   
+
 2. Input the customer story, scenario and gap (simple html editor with image and text)
+
+   .. figure:: ../business_requirement/static/img/bus_req_cust_story.png
+      :width: 600 px
 
    .. figure:: static/img/bus_req_cust_story.png
       :width: 600 px
-      :alt: Input customer story, scenario, gap
-   
+
 3. Confirm the Business requirement (for BR User and Manager)
    At that stage the Customer story/Scenario/Gap is not modifiable anymore
 
+   .. figure:: ../business_requirement/static/img/bus_req_confirmed.png
+      :width: 600 px
+
    .. figure:: static/img/bus_req_confirmed.png
       :width: 600 px
-      :alt: Confirm your business requirement
     
 4. Approve the Business requirement (for BR Manager)
 
+   .. figure:: ../business_requirement/static/img/bus_req_approved.png
+      :width: 600 px
+
    .. figure:: static/img/bus_req_approved.png
       :width: 600 px
-      :alt: Confirm your business requirement
     
 5. Once your requirement is finished and delivered you can set it as Done
 
+   .. figure:: ../business_requirement/static/img/bus_req_done.png
+      :width: 600 px
+
    .. figure:: static/img/bus_req_done.png
       :width: 600 px
-      :alt: Confirm your business requirement
     
 6. Alternatively, you can cancel the BR (in case it is not relevant or mistake) or drop it (when customer makes the decision to discontinue it)
 
+   .. figure:: ../business_requirement/static/img/bus_req_cancel.png
+      :width: 600 px
+
    .. figure:: static/img/bus_req_cancel.png
       :width: 600 px
-      :alt: Cancel your business requirement
     
     
+   .. figure:: ../business_requirement/static/img/bus_req_drop.png
+      :width: 600 px
+
    .. figure:: static/img/bus_req_drop.png
       :width: 600 px
-      :alt: Drop your business requirement
     
 
 Sub-business requirements

--- a/business_requirement/README.rst
+++ b/business_requirement/README.rst
@@ -52,7 +52,7 @@ This module is part of a set (`Business Requirements repo <https://github.com/OC
 The base Business Requirements module creates the basic objects and 
 can be used as a standalone module.
 
-.. figure:: ../business_requirement/static/img/bus_req_tree.png
+.. figure:: static/img/bus_req_tree.png
    :width: 600 px
    :alt: Business Requirement List view
 
@@ -63,13 +63,13 @@ Procurement, Project or Analytic Accounting. For example:
 * Project Tasks can be related to the BRs they implement or support
 * Procurement and purchase can be generated out of the BR
 
-.. figure:: ../business_requirement/static/img/bus_req_module_diag.png
+.. figure:: static/img/bus_req_module_diag.png
    :width: 600 px
    :alt: Business Requirement modules diagram
 
 The following workflow explains the business workflow between the BR modules and other applications in Odoo:
 
-.. figure:: ../business_requirement/static/img/bus_req_workflow.png
+.. figure:: static/img/bus_req_workflow.png
    :width: 600 px
    :alt: Business Requirement integration in Odoo
 
@@ -83,7 +83,7 @@ This module only contains the standard base models for business requirement:
 * Standard setup and views
 * Standard Workflow
 
-.. figure:: ../business_requirement/static/img/bus_req.png
+.. figure:: static/img/bus_req.png
    :width: 600 px
    :alt: Business Requirement Form
 
@@ -102,7 +102,7 @@ Alias and emails
 You can setup an alias in Settings/Technical/Email/Alias in order to create 
 business requirements directly from email received at a specific address.
 
-.. figure:: ../business_requirement/static/img/bus_req_alias.png
+.. figure:: static/img/bus_req_alias.png
    :width: 600 px
    :alt: Email Alias setup
 
@@ -123,7 +123,7 @@ Tags
 
 You can create and assign tags for your business requirements in Business Requirements/Configuration/Bus. Req. Category
 
-.. figure:: ../business_requirement/static/img/bus_req_tags.png
+.. figure:: static/img/bus_req_tags.png
    :width: 600 px
    :alt: Define Tags
 
@@ -149,43 +149,43 @@ Simple BR
    * Tags: any relevant tag for the business.
    * Owner and approver by default
    
-   .. figure:: ../business_requirement/static/img/bus_req_tags2.png
+   .. figure:: static/img/bus_req_tags2.png
       :width: 600 px
       :alt: Input header information
    
 2. Input the customer story, scenario and gap (simple html editor with image and text)
 
-   .. figure:: ../business_requirement/static/img/bus_req_cust_story.png
+   .. figure:: static/img/bus_req_cust_story.png
       :width: 600 px
       :alt: Input customer story, scenario, gap
    
 3. Confirm the Business requirement (for BR User and Manager)
    At that stage the Customer story/Scenario/Gap is not modifiable anymore
 
-   .. figure:: ../business_requirement/static/img/bus_req_confirmed.png
+   .. figure:: static/img/bus_req_confirmed.png
       :width: 600 px
       :alt: Confirm your business requirement
     
 4. Approve the Business requirement (for BR Manager)
 
-   .. figure:: ../business_requirement/static/img/bus_req_approved.png
+   .. figure:: static/img/bus_req_approved.png
       :width: 600 px
       :alt: Confirm your business requirement
     
 5. Once your requirement is finished and delivered you can set it as Done
 
-   .. figure:: ../business_requirement/static/img/bus_req_done.png
+   .. figure:: static/img/bus_req_done.png
       :width: 600 px
       :alt: Confirm your business requirement
     
 6. Alternatively, you can cancel the BR (in case it is not relevant or mistake) or drop it (when customer makes the decision to discontinue it)
 
-   .. figure:: ../business_requirement/static/img/bus_req_cancel.png
+   .. figure:: static/img/bus_req_cancel.png
       :width: 600 px
       :alt: Cancel your business requirement
     
     
-   .. figure:: ../business_requirement/static/img/bus_req_drop.png
+   .. figure:: static/img/bus_req_drop.png
       :width: 600 px
       :alt: Drop your business requirement
     


### PR DESCRIPTION
link to this issue: https://github.com/OCA/maintainer-tools/pull/221
@ pedro can we FT this one?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/OCA/business-requirement/pull/21%23issuecomment-247262649%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/21%23issuecomment-247271010%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/21%23issuecomment-247272750%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/21%23issuecomment-247594434%22%2C%20%22https%3A//github.com/OCA/business-requirement/pull/21%23issuecomment-247598235%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/OCA/business-requirement/pull/21%23issuecomment-247262649%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20like%20to%20explore%20the%20option%20of%20having%20the%202%20figure%20without%20alt%20text%20to%20see%20if%20it%27s%20rendered%20correctly%20in%20GitHub%20and%20in%20Odoo.%20Can%20you%20check%20it%3F%22%2C%20%22created_at%22%3A%20%222016-09-15T08%3A00%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7165771%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pedrobaeza%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pedrobaeza%20done.%5Cr%5CnGithub%20shows%20the%20link%20of%20the%20second%20invisible%20image.%5Cr%5CnTravis%20is%20broken%20for%20transifex%20and%20Runbot%20seems%20stalled...%22%2C%20%22created_at%22%3A%20%222016-09-15T08%3A43%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7600613%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elicoidal%22%7D%7D%2C%20%7B%22body%22%3A%20%22Travis%20was%20broken%20before%20this%20PR.%20It%27s%20something%20in%20the%20base%20module.%20We%20can%20check%20it%20later.%22%2C%20%22created_at%22%3A%20%222016-09-15T08%3A51%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7165771%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pedrobaeza%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20afraid%20any%20of%20the%20combinations%20works%20on%20apps.odoo.com%2C%20so%20we%20should%20contact%20%40odony%20for%20finding%20a%20way%20to%20put%20images%20in%20RST%20or%20a%20fix%20in%20the%20apps%20platform%20itself.%22%2C%20%22created_at%22%3A%20%222016-09-16T13%3A00%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7165771%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pedrobaeza%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20didnot%20put%20the%20./images/...%20one%20which%20I%20think%20works.%5Cr%5CnI%20could%20try%20but%20I%20dont%20think%20that%20is%20a%20solution%20anyway%3A%20we%20should%20have%20a%20common%20compatibility%20between%20Github/apps/Odoo.%5Cr%5CnI%20will%20revert%20this%20test%22%2C%20%22created_at%22%3A%20%222016-09-16T13%3A18%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7600613%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elicoidal%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/OCA/business-requirement/pull/21#issuecomment-247262649'>General Comment</a></b>
- <a href='https://github.com/pedrobaeza'><img border=0 src='https://avatars.githubusercontent.com/u/7165771?v=3' height=16 width=16'></a> I would like to explore the option of having the 2 figure without alt text to see if it's rendered correctly in GitHub and in Odoo. Can you check it?
- <a href='https://github.com/elicoidal'><img border=0 src='https://avatars.githubusercontent.com/u/7600613?v=3' height=16 width=16'></a> @pedrobaeza done.
  Github shows the link of the second invisible image.
  Travis is broken for transifex and Runbot seems stalled...
- <a href='https://github.com/pedrobaeza'><img border=0 src='https://avatars.githubusercontent.com/u/7165771?v=3' height=16 width=16'></a> Travis was broken before this PR. It's something in the base module. We can check it later.
- <a href='https://github.com/pedrobaeza'><img border=0 src='https://avatars.githubusercontent.com/u/7165771?v=3' height=16 width=16'></a> I'm afraid any of the combinations works on apps.odoo.com, so we should contact @odony for finding a way to put images in RST or a fix in the apps platform itself.
- <a href='https://github.com/elicoidal'><img border=0 src='https://avatars.githubusercontent.com/u/7600613?v=3' height=16 width=16'></a> I didnot put the ./images/... one which I think works.
  I could try but I dont think that is a solution anyway: we should have a common compatibility between Github/apps/Odoo.
  I will revert this test

<a href='https://www.codereviewhub.com/OCA/business-requirement/pull/21?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/OCA/business-requirement/pull/21?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/OCA/business-requirement/pull/21'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
