### PR TITLE
Fix misspelled field name linked_project in view of model

### DIFF
--- a/business_requirement_deliverable_project/views/business_view.xml
+++ b/business_requirement_deliverable_project/views/business_view.xml
@@ -41,7 +41,7 @@
                             type="object"
                             class="oe_highlight"
                             groups="business_requirement.group_business_requirement_manager"
-                            attrs="{'invisible': ['|', ('link_project', '!=', False), ('state', '!=', 'stakeholder_approval')]}"/>
+                            attrs="{'invisible': ['|', ('linked_project', '!=', False), ('state', '!=', 'stakeholder_approval')]}"/>
                 </xpath>
 
                 <xpath expr="//div[@name='buttons']"


### PR DESCRIPTION
In the view of module business_requirement_deliverable_project the 'attrs' attribute of generate_projects_wizard button misspells the field linked_project as link_project. This prevents the form view of the model business_requirement from loading.
