### PR TITLE
[8.0][FIX] business_requirement_deliverable_cost: fixes error during adding reso…

### DIFF
--- a/business_requirement_deliverable_cost/models/business.py
+++ b/business_requirement_deliverable_cost/models/business.py
@@ -49,8 +49,8 @@ class BusinessRequirementResource(models.Model):
         br_id = br_deliverable = False
         if self.business_requirement_deliverable_id.id:
             br_deliverable = self.business_requirement_deliverable_id
-        if br_deliverable.business_requirement_id.id:
-            br_id = br_deliverable.business_requirement_id
+            if br_deliverable.business_requirement_id.id:
+                br_id = br_deliverable.business_requirement_id
         if br_id and br_id.partner_id:
             return br_id.partner_id
         else:


### PR DESCRIPTION
During resource line addition to business requirement the error appears:

  File ".../share/Odoo/addons/8.0/business_requirement_deliverable_cost/models/business.py", line 52, in _get_partner
    if br_deliverable.business_requirement_id.id:
AttributeError: 'bool' object has no attribute 'business_requirement_id'
