### PR TITLE
[8.0][FIX] business_requirement_deliverable_project

### DIFF
--- a/business_requirement_deliverable_project/__openerp__.py
+++ b/business_requirement_deliverable_project/__openerp__.py
@@ -6,7 +6,7 @@
     'category': 'Business Requirements Management',
     'summary': 'Create projects and tasks directly from'
             ' the Business Requirement and Resources lines',
-    'version': '8.0.4.0.4',
+    'version': '8.0.4.0.5',
     'website': 'https://www.elico-corp.com/',
     "author": "Elico Corp, Odoo Community Association (OCA)",
     'depends': [

--- a/business_requirement_deliverable_project/models/project.py
+++ b/business_requirement_deliverable_project/models/project.py
@@ -72,7 +72,6 @@ class ProjectTask(models.Model):
         'business.requirement',
         string='Business Requirement',
         help='Link the task and the business requirement',
-        readonly=True,
     )
 
     br_resource_id = fields.Many2one(

--- a/business_requirement_deliverable_project/views/business_view.xml
+++ b/business_requirement_deliverable_project/views/business_view.xml
@@ -88,8 +88,7 @@
                <field name="categ_ids"
                       position="after">
                     <field name="business_requirement_id"
-                           string="Business requirement"
-                           attrs="{'invisible': ['|', ('business_requirement_id', '=', False)]}"/>
+                           string="Business requirement"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Business requirement id on Task should visible and editable
sometimes could happen have a Task not generated from BR
and needed later to be linked.