### PR TITLE
[8.0][FIX] Keep master project when generate project

### DIFF
--- a/business_requirement_deliverable_project/models/project.py
+++ b/business_requirement_deliverable_project/models/project.py
@@ -55,7 +55,7 @@ class Project(models.Model):
             br_ids.filtered(lambda br_id: not br_id.parent_id)
         vals = {
             'partner_id': self.partner_id.id,
-            'project_id': self.id,
+            'linked_project': self.id,
             'br_ids': [(6, 0, br_ids.ids)]
         }
         wizard_obj = self.env['br.generate.projects']


### PR DESCRIPTION
When generating a project from a BR, the generated project should be stored in the "Linked Project" (`linked_project`), not in the "Master Project" (`project_id`)