### PR TITLE
[8.0] Issue-161 Kanban state editable

### DIFF
--- a/business_requirement/models/business.py
+++ b/business_requirement/models/business.py
@@ -197,6 +197,13 @@ class BusinessRequirement(models.Model):
     to_be_reviewed = fields.Boolean(
         string='To be Reviewed'
     )
+    kanban_state = fields.Selection([('normal', 'In Progress'),
+                                     ('on_hold', 'On Hold'),
+                                     ('done', 'Ready for next stage')],
+                                    'Kanban State',
+                                    track_visibility='onchange',
+                                    required=False,
+                                    copy=False, default='normal')
 
     @api.multi
     @api.onchange('project_id')

--- a/business_requirement/views/business_view.xml
+++ b/business_requirement/views/business_view.xml
@@ -32,6 +32,9 @@
                                statusbar_visible="draft,confirmed,approved,stakeholder_approval,in_progress,done,cancel,drop"/>
                     </header>
                     <sheet>
+                        <div class="oe_left">
+                            <field name="kanban_state" class="oe_inline" widget="kanban_state_selection"/>
+                        </div>
                         <div class="oe_right oe_button_box" name="buttons" groups="base.group_user">
                              <button class="oe_inline oe_stat_button" type="action" name="%(act_view_sub_br_all)d" icon="fa-tasks">
                                 <field name="sub_br_count" string="Sub Bus. Req." widget="statinfo"/>

--- a/business_requirement_deliverable_project/models/business.py
+++ b/business_requirement_deliverable_project/models/business.py
@@ -43,13 +43,6 @@ class BusinessRequirement(models.Model):
         string='Total Planned Hour in RL related to business requirement',
         compute='_compute_planned_hour'
     )
-    kanban_state = fields.Selection([('normal', 'In Progress'),
-                                     ('on_hold', 'On Hold'),
-                                     ('done', 'Ready for next stage')],
-                                    'Kanban State',
-                                    track_visibility='onchange',
-                                    required=False,
-                                    copy=False, default='normal')
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0,

--- a/business_requirement_deliverable_project/views/business_view.xml
+++ b/business_requirement_deliverable_project/views/business_view.xml
@@ -28,11 +28,6 @@
             <field name="model">business.requirement</field>
             <field name="inherit_id" ref="business_requirement.view_business_requirement_form"/>
             <field name="arch" type="xml">
-                <field name="name" position="before">
-                    <div class="oe_left">
-                        <field name="kanban_state" class="oe_inline" widget="kanban_state_selection"/>
-                    </div>
-                </field>
                 <xpath expr="//header/button[@name='action_button_confirm']" position="attributes">
                     <attribute name="invisible">True</attribute>
                 </xpath>


### PR DESCRIPTION
This PR resolves the Kanban State issue #161 to make it editable from the form view of BR.

This is the simple workaround which moves the `kanban_state` field from the inherited br_project form view to the BR module main view (as for some reason it was not able to edit the field in inherited form view)

P.S: Need to find a more logical way