### PR TITLE
layout_br_base doesn't wrap long lines

### DIFF
--- a/business_requirement_deliverable_report/views/report_business_requirement.xml
+++ b/business_requirement_deliverable_report/views/report_business_requirement.xml
@@ -105,63 +105,24 @@
             </table>
 
             <t t-if="o.business_requirement">
-                <h3>Customer Story:</h3>
-                <table class="table table-bordered">
-                    <tbody>
-                        <tr>
-                            <td>
-                                <pre style="padding-left: 30px;">
-                                    <span t-field="o.business_requirement"/>
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <h3 style="width: 210mm; word-wrap: break-word;">Customer Story:</h3>
+                <span t-field="o.business_requirement"
+                      style="padding-left: 30px; width: 210mm; word-wrap: break-word; height: 100%;"/>
             </t>
 
             <t t-if="o.scenario">
-                <h3>Scenario:</h3>
-                <table class="table .table-striped">
-                    <tbody>
-                        <tr>
-                            <td>
-                                <pre style="padding-left: 30px;">
-                                    <span t-field="o.scenario"/>
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <h3  style="width: 210mm; word-wrap: break-word;">Scenario:</h3>
+                <span t-field="o.scenario"
+                      style="padding-left: 30px; width: 210mm; word-wrap: break-word; height: 100%;"/>
             </t>
 
             <t t-if="o.gap">
-                <h3>Gap:</h3>
-                <table class="table table-bordered">
-                    <tbody>
-                        <tr>
-                            <td>
-                                <pre style="padding-left: 30px;">
-                                    <span t-field="o.gap"/>
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <h3 style="width: 210mm; word-wrap: break-word;">Gap:</h3>
+                <span t-field="o.gap" style="width: 210mm; word-wrap: break-word; height: 100%;"/>
             </t>
 
             <t t-if="o.test_case">
-                <h3>Test Case:</h3>
-                <table class="table table-bordered">
-                    <tbody>
-                        <tr>
-                            <td>
-                                <pre style="padding-left: 30px;">
-                                    <t t-raw="o.test_case"/>
-                                </pre>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                <span t-field="o.test_case" style="width: 210mm; word-wrap: break-word; height: 100%;"/>
             </t>
         </template>
 

--- a/business_requirement_deliverable_report/views/report_business_requirement.xml
+++ b/business_requirement_deliverable_report/views/report_business_requirement.xml
@@ -122,6 +122,7 @@
             </t>
 
             <t t-if="o.test_case">
+                <h3 style="width: 210mm; word-wrap: break-word;">Test Case:</h3>
                 <span t-field="o.test_case" style="width: 210mm; word-wrap: break-word; height: 100%;"/>
             </t>
         </template>


### PR DESCRIPTION
It's not the perfect fix, since the page width has to be hard-coded to make word-wrap work, but since the default format you use is already A4, this should suffice to at least make the report usable, until we make t-if paper-format or something.
Another issue with wrapping is trying to fit it in a table cell, so this version gives the story, scenario, gap and test case in a normal A4 layout - actually I think this way suits the report better.