### PR TITLE
[IMP] business_requirement_deliverable: Auto-subscribe to BR followers

### DIFF
--- a/business_requirement_deliverable/__manifest__.py
+++ b/business_requirement_deliverable/__manifest__.py
@@ -19,6 +19,7 @@
     ],
     'data': [
         'data/business_data.xml',
+        'data/mail_message_subtype_data.xml',
         'security/business_requirement_deliverable_security.xml',
         'security/ir.model.access.csv',
         'views/business_view.xml',

--- a/business_requirement_deliverable/data/mail_message_subtype_data.xml
+++ b/business_requirement_deliverable/data/mail_message_subtype_data.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Both are hidden because we only want to take advantage of the auto
+         propagation of the followers from BR to BRD -->
+
+    <record id="mt_brd_new" model="mail.message.subtype">
+        <field name="name">Deliverable Created</field>
+        <field name="res_model">business.requirement.deliverable</field>
+        <field name="default" eval="False"/>
+        <field name="hidden" eval="True"/>
+        <field name="description">Deliverable Created</field>
+    </record>
+
+    <record id="mt_br_brd_new" model="mail.message.subtype">
+        <field name="name">Deliverable Created</field>
+        <field name="sequence">10</field>
+        <field name="res_model">business.requirement</field>
+        <field name="default" eval="False"/>
+        <field name="hidden" eval="True"/>
+        <field name="parent_id" eval="ref('mt_brd_new')"/>
+        <field name="relation_field">business_requirement_id</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
When creating a business requirement deliverable (BRD), auto-subscribe followers of the parent business requirement (BR), similar to what is done on tasks/projects.

This is performed automatically thanks to mail mechanisms, having a mail.message.subtype in BR having other subtype in BRD as parent. We put them as hidden, as that subtypes don't have other function than that.

cc @Tecnativa TT20662