### PR TITLE
[15.0][FIX] business_requirement: portal access error

### DIFF
--- a/business_requirement/controllers/portal.py
+++ b/business_requirement/controllers/portal.py
@@ -13,8 +13,11 @@ from odoo.addons.portal.controllers.portal import (
 class CustomerPortal(CustomerPortal):
     def _prepare_portal_layout_values(self):
         values = super()._prepare_portal_layout_values()
-        br_count = request.env["business.requirement"].search_count(
-            self._prepare_br_base_domain()
+        br_model = request.env["business.requirement"]
+        br_count = (
+            br_model.search_count(self._prepare_br_base_domain())
+            if br_model.check_access_rights("read", raise_exception=False)
+            else 0
         )
         values.update({"business_requirement_count": br_count})
         return values


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/business-requirement/pull/356

When the user has no access rights the `search` call returns an AccessError.

Please @pedrobaeza and @Tardo can you review it?

@Tecnativa TT37203